### PR TITLE
Update pypi-publish GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish distribution to PyPI  # official action from python maintainers
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
According to [pypi-publish](https://github.com/marketplace/actions/pypi-publish#-master-branch-sunset-) GitHub Marketplace site, we should use `pypa/gh-action-pypi-publish@release/v1` instead of `master` one.