### PR TITLE
Fix batch query result collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Add backticks to escape table/database/catalog names
 -   Print error if query execution fails
+-   Fix TableResult#wait() timeout parameter
 
 ## [0.8.2] - 2022-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ### Fixed
 
--   Add backticks to escape table/database/catalog names
--   Print error if query execution fails
--   Fix TableResult#wait() timeout parameter
+-   Add backticks to escape table/database/catalog names.
+-   Print error if query execution fails.
+-   Fix TableResult#wait() timeout parameter.
+-   Fix for batch queries with an empty result.
 
 ## [0.8.2] - 2022-10-07
 

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -66,7 +66,8 @@ class Integrations(Magics):
         self.jar_handler = JarHandler(project_root_dir=os.getcwd())
         self.__load_plugins()
         self.interrupted = False
-        self.polling_ms = 100
+        # Wait if necessary for at most the given time for the data to be ready.
+        self.wait_timeout_ms = 60 * 60 * 1000  # 1H
         # 20ms
         self.async_wait_s = 2e-2
         Integrations.__enable_sql_syntax_highlighting()
@@ -201,7 +202,7 @@ class Integrations(Magics):
                 # Explicit await is needed to unblock the main thread to pick up other tasks.
                 # In Jupyter's main execution pool there is only one worker thread.
                 await asyncio.sleep(self.async_wait_s)
-                execution_result.wait(self.polling_ms)
+                execution_result.wait(self.wait_timeout_ms)
                 if is_dql(stmt):
                     # if a select query has been executing then `wait` returns as soon as the first
                     # row is available. To display the results

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -202,7 +202,6 @@ class Integrations(Magics):
                 # Explicit await is needed to unblock the main thread to pick up other tasks.
                 # In Jupyter's main execution pool there is only one worker thread.
                 await asyncio.sleep(self.async_wait_s)
-                execution_result.wait(self.wait_timeout_ms)
                 if is_dql(stmt):
                     # if a select query has been executing then `wait` returns as soon as the first
                     # row is available. To display the results
@@ -212,6 +211,7 @@ class Integrations(Magics):
                 else:
                     # if finished then return early even if the user interrupts after this
                     # the actual invocation has already finished
+                    execution_result.wait(self.wait_timeout_ms)
                     print(successful_execution_msg)
                     return
             except Py4JJavaError as err:


### PR DESCRIPTION
 * Fix TableResult#wait() timeout parameter. If the parameter is too low, some rows may be dropped.
 * `execution_result.wait(self.wait_timeout_ms)` does not finish when SELECT query return empty results. Other queries either return immediately or always return at least one row. Therefore, we can call `wait()` on queries other than SELECT. In case of SELECT queries, we can block on `CloseableIterator<Row>` returned by `collect()` method.
