### PR TITLE
Support multiple execution targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+-   Support for execution targets: local, remote, yarn-session.
+
 ## [0.9.1] - 2022-10-25
 
 ### Added
 
 -   Show functions & change icon for views in `%flink_show_table_tree`
--   Support for execution targets: local, remote, yarn-session.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 -   Show functions & change icon for views in `%flink_show_table_tree`
+-   Support for execution targets: local, remote, yarn-session.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -136,15 +136,6 @@ CREATE TABLE MyUserTable (
    'password' = '${my_password}'
 );
 ```
-
-## Batch mode
-
-You can run Flink in batch mode by setting `FLINK_MODE` environment variable before loading magics.
-
-```ipython
-%env FLINK_MODE=batch
-```
-
 ---
 
 ## Local development

--- a/README.md
+++ b/README.md
@@ -8,16 +8,108 @@
 
 Streaming Jupyter Integrations project includes a set of magics for interactively running _Flink SQL_  jobs in [Jupyter](https://jupyter.org/) Notebooks
 
+## Installation
+
 In order to actually use these magics, you must install our PIP package along `jupyterlab-lsp`:
 
 ```shell
 python3 -m pip install jupyterlab-lsp streaming-jupyter-integrations
 ```
 
-And then register in Jupyter with a running IPython in the first cell:
+## Usage
+
+Register in Jupyter with a running IPython in the first cell:
 
 ```python
 %load_ext streaming_jupyter_integrations.magics
+```
+
+Then you need to decide which _execution mode_ and _execution target_ to choose.
+
+```python
+%flink_connect --execution-mode [mode] --execution-target [target]
+```
+
+By default, the streaming execution mode and local execution target are used.
+
+```python
+%flink_connect
+```
+
+### Execution mode
+
+Currently, Flink supports two execution modes: _batch_ and _streaming_. Please see
+[Flink documentation](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/execution_mode/)
+for more details.
+
+In order to specify execution mode, add `--execution-mode` parameter, for instance:
+```python
+%flink_connect --execution-mode batch
+```
+
+### Execution target
+
+Streaming Jupyter Integrations supports 3 execution targets:
+* Local
+* Remote
+* YARN Session
+
+#### Local execution target
+
+Running Flink in `local` mode will start a MiniCluster in a local JVM with parallelism 1.
+
+In order to run Flink locally, use:
+```python
+%flink_connect --execution-target local
+```
+
+Alternatively, since the execution target is `local` by default, use:
+```python
+%flink_connect
+```
+
+#### Remote execution target
+
+Running Flink in remote mode will connect to an existing Flink session cluster. Besides specifying `--execution-target`
+to be `remote`, you also need to specify `--remote-hostname` and `--remote-port` pointing to Flink Job Manager's
+REST API address.
+
+```python
+%flink_connect \
+    --execution-target remote \
+    --remote-hostname example.com \
+    --remote-port 8888
+```
+
+#### YARN session execution target
+
+Running Flink in `yarn-session` mode will connect to an existing Flink session cluster running on YARN. Besides
+specifying `--execution-target` to be `yarn-session` you also need to specify the hostname and port of the
+YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`). If hostname and port are
+not specified, it is assumed that the notebook runs on the cluster's master node, that is, on the same host as the
+YARN Resource Manager. You can also specify YARN applicationId (`--yarn-application-id`) to which the notebook will
+connect to. If `--yarn-application-id` is not specified, the notebook will connect to the only YARN application running
+on the cluster. If there are more than one running application, the command will fail.
+
+Connecting to a remote Flink session cluster running on a remote YARN cluster:
+```python
+%flink_connect \
+    --execution-target yarn-session \
+    --resource-manager-hostname example.com \
+    --resource-manager-port 8888 \
+    --yarn-application-id application_1666172784500_0001
+```
+
+Connecting to a Flink session cluster running on a YARN cluster:
+```python
+%flink_connect \
+    --execution-target yarn-session \
+    --yarn-application-id application_1666172784500_0001
+```
+
+Connecting to a Flink session cluster running on a dedicated YARN cluster:
+```python
+%flink_connect --execution-target yarn-session
 ```
 
 ## Variables
@@ -53,6 +145,8 @@ You can run Flink in batch mode by setting `FLINK_MODE` environment variable bef
 ```ipython
 %env FLINK_MODE=batch
 ```
+
+---
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ REST API address.
 
 #### YARN session execution target
 
-Running Flink in `yarn-session` mode will connect to an existing Flink session cluster running on YARN. Besides
-specifying `--execution-target` to be `yarn-session` you also need to specify the hostname and port of the
-YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`). If hostname and port are
-not specified, it is assumed that the notebook runs on the cluster's master node, that is, on the same host as the
-YARN Resource Manager. You can also specify YARN applicationId (`--yarn-application-id`) to which the notebook will
-connect to. If `--yarn-application-id` is not specified, the notebook will connect to the only YARN application running
-on the cluster. If there are more than one running application, the command will fail.
+Running Flink in `yarn-session` mode will connect to an existing Flink session cluster running on YARN. You may specify
+the hostname and port of the YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`).
+If Resource Manager address is not provided, the address is extracted from Hadoop configuration files
+(`$HADOOP_CONF_DIR/yarn-site.xml` file is searched). You can also specify YARN applicationId (`--yarn-application-id`)
+to which the notebook will connect to. If `--yarn-application-id` is not specified, the notebook will connect to
+the only YARN application running on the cluster. If there are more than one running application, the command will fail.
 
 Connecting to a remote Flink session cluster running on a remote YARN cluster:
 ```python

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ REST API address.
 
 Running Flink in `yarn-session` mode will connect to an existing Flink session cluster running on YARN. You may specify
 the hostname and port of the YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`).
-If Resource Manager address is not provided, the address is extracted from YARN configuration file
-`$HADOOP_CONF_DIR/yarn-site.xml`. You can also specify YARN applicationId (`--yarn-application-id`)
-to which the notebook will connect to. If `--yarn-application-id` is not specified and there is one YARN application
-running on the cluster, the notebook will try to connect to it. Otherwise, it will  fail.
+If Resource Manager address is not provided, it is assumed that notebook runs on the same node as Resource Manager.
+You can also specify YARN applicationId (`--yarn-application-id`) to which the notebook will connect to.
+If `--yarn-application-id` is not specified and there is one YARN application running on the cluster, the notebook will
+try to connect to it. Otherwise, it will fail.
 
 Connecting to a remote Flink session cluster running on a remote YARN cluster:
 ```python

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then you need to decide which _execution mode_ and _execution target_ to choose.
 %flink_connect --execution-mode [mode] --execution-target [target]
 ```
 
-By default, the streaming execution mode and local execution target are used.
+By default, the `streaming` execution mode and `local` execution target are used.
 
 ```python
 %flink_connect
@@ -85,8 +85,8 @@ REST API address.
 
 Running Flink in `yarn-session` mode will connect to an existing Flink session cluster running on YARN. You may specify
 the hostname and port of the YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`).
-If Resource Manager address is not provided, the address is extracted from Hadoop configuration files
-(`$HADOOP_CONF_DIR/yarn-site.xml` file is searched). You can also specify YARN applicationId (`--yarn-application-id`)
+If Resource Manager address is not provided, the address is extracted from YARN configuration file
+`$HADOOP_CONF_DIR/yarn-site.xml`. You can also specify YARN applicationId (`--yarn-application-id`)
 to which the notebook will connect to. If `--yarn-application-id` is not specified, the notebook will connect to
 the only YARN application running on the cluster. If there are more than one running application, the command will fail.
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Running Flink in `yarn-session` mode will connect to an existing Flink session c
 the hostname and port of the YARN Resource Manager (`--resource-manager-hostname` and `--resource-manager-port`).
 If Resource Manager address is not provided, the address is extracted from YARN configuration file
 `$HADOOP_CONF_DIR/yarn-site.xml`. You can also specify YARN applicationId (`--yarn-application-id`)
-to which the notebook will connect to. If `--yarn-application-id` is not specified, the notebook will connect to
-the only YARN application running on the cluster. If there are more than one running application, the command will fail.
+to which the notebook will connect to. If `--yarn-application-id` is not specified and there is one YARN application
+running on the cluster, the notebook will try to connect to it. Otherwise, it will  fail.
 
 Connecting to a remote Flink session cluster running on a remote YARN cluster:
 ```python

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "54f4e654",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c99e3966",
    "metadata": {},
    "outputs": [],

--- a/examples/basic_with_config.ipynb
+++ b/examples/basic_with_config.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca7c567e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "03078738",
    "metadata": {
     "pycharm": {

--- a/examples/basic_with_password_variables.ipynb
+++ b/examples/basic_with_password_variables.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1aad95f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "df8db376",
    "metadata": {},

--- a/examples/basic_with_variables.ipynb
+++ b/examples/basic_with_variables.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d50529ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c6429bce",
    "metadata": {
     "pycharm": {

--- a/examples/flink_show_table_tree.ipynb
+++ b/examples/flink_show_table_tree.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ac2b72cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "77f399d3",
    "metadata": {},
    "outputs": [],

--- a/examples/local_java_udf.ipynb
+++ b/examples/local_java_udf.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1d545395",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "efa43a45",
    "metadata": {},
    "outputs": [],

--- a/examples/remote_java_udf.ipynb
+++ b/examples/remote_java_udf.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0e8542d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "01a3a234",
    "metadata": {},
    "outputs": [],

--- a/examples/udf.ipynb
+++ b/examples/udf.ipynb
@@ -13,6 +13,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "be79b73e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%flink_connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "914bea5f",
    "metadata": {},
    "outputs": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ wget
 sqlparse
 pyyaml
 types-PyYAML
+yarn-api-client

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ EXTRA_REQUIRE = {
         "pre-commit==2.15.0",
         "tox==3.21.1",
         "jupyter-packaging>=0.12.2",
+        "responses>=0.22.0",
     ]
 }
 

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -83,7 +83,7 @@ class Integrations(Magics):
         args = parse_argstring(self.flink_connect, line)
         try:
             self._flink_connect(args)
-        except ValueError as e:
+        except Exception as e:
             print(e, file=sys.stderr)
 
     def _flink_connect(self, args: Any) -> None:
@@ -93,6 +93,8 @@ class Integrations(Magics):
         if execution_target == "local":
             self._flink_connect_local()
         elif execution_target == "remote":
+            if not args.remote_hostname or not args.remote_port:
+                raise ValueError("Remote execution target requires --remote-hostname and --remote-port parameters.")
             self._flink_connect_remote(args.remote_hostname, args.remote_port)
         elif execution_target == "yarn-session":
             self._flink_connect_yarn_session(args.resource_manager_hostname, args.resource_manager_port,

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -83,7 +83,7 @@ class Integrations(Magics):
         args = parse_argstring(self.flink_connect, line)
         try:
             self._flink_connect(args)
-        except Exception as e:
+        except Exception as e:  # noqa: B902
             print(e, file=sys.stderr)
 
     def _flink_connect(self, args: Any) -> None:

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -72,7 +72,7 @@ class Integrations(Magics):
     @magic_arguments()
     @argument("-e", "--execution-mode", type=str, help="Flink execution mode", required=False,
               default="streaming")
-    @argument("-m", "--execution-target", type=str, help="The target on which queries will be executed", required=False,
+    @argument("-t", "--execution-target", type=str, help="The target on which queries will be executed", required=False,
               default="local")
     @argument("-h", "--remote-hostname", type=str, help="Hostname of the remote JobManager", required=False)
     @argument("-p", "--remote-port", type=int, help="Port of the remote JobManager", required=False)
@@ -81,6 +81,12 @@ class Integrations(Magics):
     @argument("-yid", "--yarn-application-id", type=str, help="Flink Session Cluster applicationId", required=False)
     def flink_connect(self, line: str) -> None:
         args = parse_argstring(self.flink_connect, line)
+        try:
+            self._flink_connect(args)
+        except ValueError as e:
+            print(e, file=sys.stderr)
+
+    def _flink_connect(self, args: Any) -> None:
         execution_mode = args.execution_mode
         execution_target = args.execution_target
 
@@ -92,8 +98,8 @@ class Integrations(Magics):
             self._flink_connect_yarn_session(args.resource_manager_hostname, args.resource_manager_port,
                                              args.yarn_application_id)
         else:
-            print("Unknown execution mode. Expected 'local', 'remote' or 'yarn-session', actual '{execution_mode}'.")
-            return None
+            raise ValueError(
+                f"Unknown execution mode. Expected 'local', 'remote' or 'yarn-session', actual '{execution_target}'.")
 
         self.__flink_execute_sql_file("init.sql")
         self._set_table_env(execution_mode)

--- a/streaming_jupyter_integrations/yarn.py
+++ b/streaming_jupyter_integrations/yarn.py
@@ -1,20 +1,47 @@
-import socket
-import typing
+from typing import Any, Optional, Tuple
 
 from yarn_api_client.resource_manager import ResourceManager
 
 
 class ResourceManagerClient:
-    def __init__(self, rm_hostname: typing.Optional[str] = None, rm_port: typing.Optional[int] = None):
-        rm_hostname = rm_hostname if rm_hostname else socket.getfqdn()
-        rm_port = rm_port if rm_port else 8088
-        self.rm_client = ResourceManager(service_endpoints=[f"http://{rm_hostname}:{rm_port}"])
+    def __init__(self, rm_hostname: Optional[str] = None, rm_port: Optional[int] = None):
+        self.rm_client = ResourceManager(
+            service_endpoints=[f"http://{rm_hostname}:{rm_port}"] if rm_hostname and rm_port else None
+        )
 
-    def list_yarn_applications(self) -> typing.Any:
+    def list_yarn_applications(self) -> Any:
         applications = self.rm_client.cluster_applications()
         if not applications or not applications.data or not applications.data["apps"]:
             return []
         return applications.data["apps"]["app"]
 
-    def describe_application(self, application_id: str) -> typing.Any:
+    def describe_application(self, application_id: str) -> Any:
         return self.rm_client.cluster_application(application_id).data["app"]
+
+
+def find_session_jm_address(rm_hostname: Optional[str], rm_port: Optional[int],
+                            yarn_application_id: Optional[str]) -> Tuple[str, int]:
+    if rm_hostname and rm_port:
+        rm_client = ResourceManagerClient(rm_hostname, rm_port)
+    else:
+        rm_client = ResourceManagerClient()
+    if yarn_application_id is None:
+        yarn_application_id = __find_yarn_application_id(rm_client)
+
+    app_metadata = rm_client.describe_application(yarn_application_id)
+    address = app_metadata["amRPCAddress"]
+    address_parts = address.rsplit(":", 1)
+    hostname = address_parts[0]
+    port = int(address_parts[1])
+    return hostname, port
+
+
+def __find_yarn_application_id(rm_client: ResourceManagerClient) -> str:
+    yarn_apps = rm_client.list_yarn_applications()
+    yarn_apps_count = len(yarn_apps)
+    if yarn_apps_count == 0:
+        raise ValueError("No running YARN applications found.")
+    elif yarn_apps_count > 1:
+        raise ValueError(f"Expected one running YARN application, but {yarn_apps_count} found.")
+    else:
+        return yarn_apps[0]["id"]

--- a/streaming_jupyter_integrations/yarn.py
+++ b/streaming_jupyter_integrations/yarn.py
@@ -1,0 +1,20 @@
+import socket
+import typing
+
+from yarn_api_client.resource_manager import ResourceManager
+
+
+class ResourceManagerClient:
+    def __init__(self, rm_hostname: typing.Optional[str] = None, rm_port: typing.Optional[int] = None):
+        rm_hostname = rm_hostname if rm_hostname else socket.getfqdn()
+        rm_port = rm_port if rm_port else 8088
+        self.rm_client = ResourceManager(service_endpoints=[f"http://{rm_hostname}:{rm_port}"])
+
+    def list_yarn_applications(self) -> typing.Any:
+        applications = self.rm_client.cluster_applications()
+        if not applications or not applications.data or not applications.data["apps"]:
+            return []
+        return applications.data["apps"]["app"]
+
+    def describe_application(self, application_id: str) -> typing.Any:
+        return self.rm_client.cluster_application(application_id).data["app"]

--- a/streaming_jupyter_integrations/yarn.py
+++ b/streaming_jupyter_integrations/yarn.py
@@ -1,3 +1,4 @@
+import socket
 from typing import Any, Optional, Tuple
 
 from yarn_api_client.resource_manager import ResourceManager
@@ -5,9 +6,11 @@ from yarn_api_client.resource_manager import ResourceManager
 
 class ResourceManagerClient:
     def __init__(self, rm_hostname: Optional[str] = None, rm_port: Optional[int] = None):
-        self.rm_client = ResourceManager(
-            service_endpoints=[f"http://{rm_hostname}:{rm_port}"] if rm_hostname and rm_port else None
-        )
+        if rm_hostname is None:
+            rm_hostname = socket.getfqdn()
+        if rm_port is None:
+            rm_port = 8088
+        self.rm_client = ResourceManager(service_endpoints=[f"http://{rm_hostname}:{rm_port}"])
 
     def list_yarn_applications(self) -> Any:
         applications = self.rm_client.cluster_applications()

--- a/tests/test_yarn.py
+++ b/tests/test_yarn.py
@@ -1,0 +1,105 @@
+import unittest
+
+import responses
+from yarn_api_client.errors import APIError
+
+from streaming_jupyter_integrations.yarn import find_session_jm_address
+
+
+class TestYarn(unittest.TestCase):
+    APP1_DATA = {
+        "id": "application_1666172784500_0001",
+        "name": "queries-session-cluster",
+        "amRPCAddress": "node-1.example.com:35331"
+    }
+    APP2_DATA = {
+        "id": "application_1666172784500_0002",
+        "name": "another-yarn-application",
+        "amRPCAddress": "node-1.example.com:46921"
+    }
+
+    @responses.activate
+    def test_should_fetch_job_manager_address(self):
+        self._mock_cluster_call()
+        self._mock_cluster_apps_success([self.APP1_DATA])
+        self._mock_cluster_app_success(self.APP1_DATA)
+
+        hostname, port = find_session_jm_address(rm_hostname="example.com", rm_port=8123, yarn_application_id=None)
+
+        self.assertEqual(hostname, "node-1.example.com")
+        self.assertEqual(port, 35331)
+
+    @responses.activate
+    def test_should_fetch_job_manager_address_when_yarn_app_is_provided(self):
+        self._mock_cluster_call()
+        self._mock_cluster_apps_success([self.APP1_DATA, self.APP2_DATA])
+        self._mock_cluster_app_success(self.APP1_DATA)
+        self._mock_cluster_app_success(self.APP2_DATA)
+
+        hostname, port = find_session_jm_address(rm_hostname="example.com", rm_port=8123,
+                                                 yarn_application_id=self.APP2_DATA["id"])
+
+        self.assertEqual(hostname, "node-1.example.com")
+        self.assertEqual(port, 46921)
+
+    @responses.activate
+    def test_should_fail_if_app_does_not_exist(self):
+        self._mock_cluster_call()
+        self._mock_cluster_apps_success([self.APP1_DATA])
+        self._mock_cluster_app_not_found(self.APP1_DATA["id"])
+
+        with self.assertRaises(APIError) as e:
+            find_session_jm_address(rm_hostname="example.com", rm_port=8123, yarn_application_id=self.APP1_DATA["id"])
+        self.assertRegex(str(e.exception), "Response finished with status: 404.*")
+
+    @responses.activate
+    def test_should_fail_if_no_yarn_application_running(self):
+        self._mock_cluster_call()
+        self._mock_cluster_apps_success([])
+
+        with self.assertRaises(ValueError) as e:
+            find_session_jm_address(rm_hostname="example.com", rm_port=8123, yarn_application_id=None)
+        self.assertEqual(str(e.exception), "No running YARN applications found.")
+
+    @responses.activate
+    def test_should_fail_if_there_are_many_yarn_application_running(self):
+        self._mock_cluster_call()
+        self._mock_cluster_apps_success([self.APP1_DATA, self.APP2_DATA])
+
+        with self.assertRaises(ValueError) as e:
+            find_session_jm_address(rm_hostname="example.com", rm_port=8123, yarn_application_id=None)
+        self.assertEqual(str(e.exception), "Expected one running YARN application, but 2 found.")
+
+    @staticmethod
+    def _mock_cluster_call():
+        responses.add(
+            responses.GET,
+            "http://example.com:8123/cluster",
+            json={},
+            status=200,
+        )
+
+    @staticmethod
+    def _mock_cluster_apps_success(apps_list):
+        responses.add(
+            responses.GET,
+            "http://example.com:8123/ws/v1/cluster/apps",
+            json={"apps": {"app": apps_list}},
+            status=200,
+        )
+
+    def _mock_cluster_app_success(self, app):
+        responses.add(
+            responses.GET,
+            f"http://example.com:8123/ws/v1/cluster/apps/{app['id']}",
+            json={"app": app},
+            status=200,
+        )
+
+    def _mock_cluster_app_not_found(self, app_id):
+        responses.add(
+            responses.GET,
+            f"http://example.com:8123/ws/v1/cluster/apps/{app_id}",
+            json={},
+            status=404,
+        )

--- a/tests/test_yarn.py
+++ b/tests/test_yarn.py
@@ -88,7 +88,8 @@ class TestYarn(unittest.TestCase):
             status=200,
         )
 
-    def _mock_cluster_app_success(self, app):
+    @staticmethod
+    def _mock_cluster_app_success(app):
         responses.add(
             responses.GET,
             f"http://example.com:8123/ws/v1/cluster/apps/{app['id']}",
@@ -96,7 +97,8 @@ class TestYarn(unittest.TestCase):
             status=200,
         )
 
-    def _mock_cluster_app_not_found(self, app_id):
+    @staticmethod
+    def _mock_cluster_app_not_found(app_id):
         responses.add(
             responses.GET,
             f"http://example.com:8123/ws/v1/cluster/apps/{app_id}",


### PR DESCRIPTION
So far only local execution target has been supported. Now a user can run SQLs locally, remotely or on yarn.