### PR TITLE
Speed up results display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fix execution of SHOW, EXPLAIN and DESCRIBE commands.
+-   Speed up results display.
 
 ## [0.12.0] - 2022-11-30
 

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -43,6 +43,7 @@ from .yarn import find_session_jm_address
 
 @magics_class
 class Integrations(Magics):
+
     def __init__(self, shell: Any):
         super(Integrations, self).__init__(shell)
         self._secrets: Dict[str, str] = {}
@@ -55,6 +56,7 @@ class Integrations(Magics):
         self.wait_timeout_ms = 60 * 60 * 1000  # 1H
         # 20ms
         self.async_wait_s = 2e-2
+        self.result_display_sleep_step = 25
         Integrations.__enable_sql_syntax_highlighting()
         self.deployment_bar = DeploymentBar(interrupt_callback=self.__interrupt_execute)
         # Indicates whether a job is executing on the Flink cluster in the background
@@ -405,7 +407,7 @@ class Integrations(Magics):
                 display_handle = None
                 for result in results:
                     # Explicit await for the same reason as in `__internal_execute_sql`
-                    if rows_counter.value % 25 == 0:
+                    if rows_counter.value % self.result_display_sleep_step == 0:
                         # Sleeping for each row slows down showing the results significantly.
                         await asyncio.sleep(self.async_wait_s)
                     res = list(result)

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -56,7 +56,7 @@ class Integrations(Magics):
         self.wait_timeout_ms = 60 * 60 * 1000  # 1H
         # 20ms
         self.async_wait_s = 2e-2
-        self.result_display_sleep_step = 25
+        self.display_results_batch_size = 25
         Integrations.__enable_sql_syntax_highlighting()
         self.deployment_bar = DeploymentBar(interrupt_callback=self.__interrupt_execute)
         # Indicates whether a job is executing on the Flink cluster in the background
@@ -407,7 +407,7 @@ class Integrations(Magics):
                 display_handle = None
                 for result in results:
                     # Explicit await for the same reason as in `__internal_execute_sql`
-                    if rows_counter.value % self.result_display_sleep_step == 0:
+                    if rows_counter.value % self.display_results_batch_size == 0:
                         # Sleeping for each row slows down showing the results significantly.
                         await asyncio.sleep(self.async_wait_s)
                     res = list(result)

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -405,7 +405,9 @@ class Integrations(Magics):
                 display_handle = None
                 for result in results:
                     # Explicit await for the same reason as in `__internal_execute_sql`
-                    await asyncio.sleep(self.async_wait_s)
+                    if rows_counter.value % 25 == 0:
+                        # Sleeping for each row slows down showing the results significantly.
+                        await asyncio.sleep(self.async_wait_s)
                     res = list(result)
                     if display_row_kind:
                         res = [result.get_row_kind()] + res


### PR DESCRIPTION
Previously, there was a short sleep after reading each record. In consequence, it took at least a few secods to show tens or hundreds of rows.