### PR TITLE
Fixed connecting to a remote cluster when `pipeline.jars` empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed connecting to a remote cluster when `pipeline.jars` property is empty.
+
 ## [0.13.0] - 2023-01-17
 
 ### Added

--- a/streaming_jupyter_integrations/magics.py
+++ b/streaming_jupyter_integrations/magics.py
@@ -163,7 +163,7 @@ class Integrations(Magics):
         # (org.apache.flink.api.java.RemoteEnvironmentConfigUtils#getJarFiles). On the other hand, jars specified in
         # "pipeline.jars" have to contain the schema. Therefore, we need to remove the schema on our own.
         gateway = get_gateway()
-        pipeline_jars = conf.get_string("pipeline.jars", "").split(";")
+        pipeline_jars = list(filter(lambda p: p, conf.get_string("pipeline.jars", "").split(";")))
         result = gateway.new_array(gateway.jvm.String, len(pipeline_jars))
         for i in range(len(pipeline_jars)):
             result[i] = pipeline_jars[i].replace("file://", "")


### PR DESCRIPTION
When `pipeline.jars` is empty `[""]` was returned instead of an empty list.