### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0",
     "@types/codemirror": "^5.60.5",
+    "@types/node": "18.14.0",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "codemirror": "~5.65.7",


### PR DESCRIPTION
@types/node in version 18.14.1 breaks the build. Downgrading
it to 18.14.0.